### PR TITLE
fix: images are not fully visible

### DIFF
--- a/assets/css/varnalab.css
+++ b/assets/css/varnalab.css
@@ -171,6 +171,7 @@ h1 {
 .v-card-slider .mdc-card__media {
   position: relative;
   padding: 0;
+  background-size: contain;
 }
 .v-card-slider .mdc-card__title {
   background: rgba(0, 0, 0, .7);


### PR DESCRIPTION
This prevent situations like seeing:
"ails Girls..." instead of "Rails Girls..."